### PR TITLE
Add postcss generated `globals.css` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# postcss generated
+styles/globals.css
+


### PR DESCRIPTION
- Suppresses possibility that `globals.css` is added to repo
- Removes assumption that a committed `globals.css` doesn't need regeneration
- Fixes #1 