### PR TITLE
Simplify running `dev` by running `postcss` in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ npm run dev
 yarn dev
 ```
 
-To get JIT Tailwind as you develop, you also need to run:
-
-```bash
-npm run css:dev
-# or
-yarn css:dev
-```
-
 For testing, run:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "(export PATH=$(npm bin):$PATH; trap 'jobs -pr | xargs kill' EXIT; TAILWIND_MODE=watch postcss ./styles/tailwind.css -o ./styles/globals.css --watch & next dev)",
+		"dev": "(export PATH=$(npm bin):$PATH; trap 'jobs -pr | xargs kill' EXIT; TAILWIND_MODE=watch postcss ./styles/tailwind.css -o ./styles/globals.css --watch </dev/zero & next dev)",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",

--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev",
+		"dev": "(export PATH=$(npm bin):$PATH; trap 'jobs -pr | xargs kill' EXIT; TAILWIND_MODE=watch postcss ./styles/tailwind.css -o ./styles/globals.css --watch & next dev)",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",
-		"css:dev": "TAILWIND_MODE=watch postcss ./styles/tailwind.css -o ./styles/globals.css --watch",
 		"css:build": "postcss ./styles/tailwind.css -o ./styles/globals.css",
 		"test": "jest"
 	},


### PR DESCRIPTION
- Removes the need to run two separate terminals for development
- Runs `next dev` and `postcss` in a subshell
- When `next dev` that is running in the forground exits, the signal is trapped so all subshell background job(s) are ended
- Assumes current state that `dev` script needs to be modified for Windows anyways
- Resolves #3, fixes #5 