### PR TITLE
fix import typo in _app.tsx

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-import '@styles/globals.css';
+import '@styles/tailwind.css';
 import type { AppProps } from 'next/app';
 
 function MyApp({ Component, pageProps }: AppProps) {


### PR DESCRIPTION
Hi Antonio,

I read your [article](https://blog.antoniolofiego.com/setting-up-a-nextjs-application-with-typescript-jit-tailwind-css-and-jestreact-testing-library) and clone the repo to play. It's awesome but with a little typo cause crashing, so I sent a pull request to fix it.